### PR TITLE
Fix: </head> tag being removed

### DIFF
--- a/src/Prime/Http/ResponseExtension.php
+++ b/src/Prime/Http/ResponseExtension.php
@@ -61,8 +61,9 @@ final class ResponseExtension
         }
 
         $htmlResponse = "\n".str_replace("\n", '', $htmlResponse)."\n";
+        $offset = $alreadyRendered ? strlen(HtmlPresenter::FLASHER_FLASH_BAG_PLACE_HOLDER) : 0;
 
-        $content = substr($content, 0, $insertPosition).$htmlResponse.substr($content, $insertPosition);
+        $content = substr($content, 0, $insertPosition).$htmlResponse.substr($content, $insertPosition + $offset);
         $response->setContent($content);
 
         return $response;

--- a/src/Prime/Http/ResponseExtension.php
+++ b/src/Prime/Http/ResponseExtension.php
@@ -62,7 +62,7 @@ final class ResponseExtension
 
         $htmlResponse = "\n".str_replace("\n", '', $htmlResponse)."\n";
 
-        $content = substr($content, 0, $insertPosition).$htmlResponse.substr($content, $insertPosition + \strlen($insertPlaceHolder));
+        $content = substr($content, 0, $insertPosition).$htmlResponse.substr($content, $insertPosition);
         $response->setContent($content);
 
         return $response;


### PR DESCRIPTION
Hi!
I've noticed the problem with auto-inject feature of this package.

As you can see, the closing head tag is not present here.
<img width="579" alt="image" src="https://github.com/php-flasher/php-flasher/assets/5730766/009fbd56-507c-4797-8f54-8c239aa44199">

That is because of too big of an offset.

After removing the offset, it works correctly:
<img width="152" alt="image" src="https://github.com/php-flasher/php-flasher/assets/5730766/b70bcf49-6381-4d14-87e7-1b0628eae7f7">

However, we also want to remove the placeholder if it's not an HTML tag, hence the if tag there:
<img width="315" alt="image" src="https://github.com/php-flasher/php-flasher/assets/5730766/fbb12996-4671-4e6f-8d4a-03be4f6b7fe1">

