### PR TITLE
Update config.yaml  # after a line blocked the flasher.yaml to be parsed by symfony7

### DIFF
--- a/src/Symfony/Resources/config/config.yaml
+++ b/src/Symfony/Resources/config/config.yaml
@@ -170,4 +170,4 @@ flasher:
     #     types: ['error'],
     #
     filter_criteria:
-        limit: 5 # Limit the number of notifications to display
+        limit: 5


### PR DESCRIPTION
Cause trouble in symfony7 where flasher.yaml wasn't interpreted due to the # comment after limit: 5

No error returned, took some times to understand why flasher.yaml wasn't interpreted.
