### PR TITLE
chore: Refactor middleware to use Symfony's base response class

### DIFF
--- a/src/Laravel/Http/Response.php
+++ b/src/Laravel/Http/Response.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Flasher\Laravel\Http;
 
 use Flasher\Prime\Http\ResponseInterface;
-use Illuminate\Http\JsonResponse as LaravelJsonResponse;
 use Illuminate\Http\Response as LaravelResponse;
+use Symfony\Component\HttpFoundation\JsonResponse as SymfonyJsonResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 final readonly class Response implements ResponseInterface
 {
-    public function __construct(private LaravelJsonResponse|LaravelResponse $response)
+    public function __construct(private SymfonyResponse $response)
     {
     }
 
@@ -21,7 +22,7 @@ final readonly class Response implements ResponseInterface
 
     public function isJson(): bool
     {
-        return $this->response instanceof LaravelJsonResponse;
+        return $this->response instanceof SymfonyJsonResponse;
     }
 
     public function isHtml(): bool
@@ -66,7 +67,7 @@ final readonly class Response implements ResponseInterface
         $this->response->setContent($content);
 
         // Restore original response (eg. the View or Ajax data)
-        if ($original) {
+        if ($original && $this->response instanceof LaravelResponse) {
             $this->response->original = $original;
         }
     }

--- a/src/Laravel/Middleware/FlasherMiddleware.php
+++ b/src/Laravel/Middleware/FlasherMiddleware.php
@@ -7,9 +7,8 @@ namespace Flasher\Laravel\Middleware;
 use Flasher\Laravel\Http\Request;
 use Flasher\Laravel\Http\Response;
 use Flasher\Prime\Http\ResponseExtensionInterface;
-use Illuminate\Http\JsonResponse as LaravelJsonResponse;
 use Illuminate\Http\Request as LaravelRequest;
-use Illuminate\Http\Response as LaravelResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 final readonly class FlasherMiddleware
 {
@@ -21,7 +20,7 @@ final readonly class FlasherMiddleware
     {
         $response = $next($request);
 
-        if ($response instanceof LaravelJsonResponse || $response instanceof LaravelResponse) {
+        if ($response instanceof SymfonyResponse) {
             $this->responseExtension->render(new Request($request), new Response($response));
         }
 

--- a/src/Laravel/Middleware/SessionMiddleware.php
+++ b/src/Laravel/Middleware/SessionMiddleware.php
@@ -7,9 +7,8 @@ namespace Flasher\Laravel\Middleware;
 use Flasher\Laravel\Http\Request;
 use Flasher\Laravel\Http\Response;
 use Flasher\Prime\Http\RequestExtensionInterface;
-use Illuminate\Http\JsonResponse as LaravelJsonResponse;
 use Illuminate\Http\Request as LaravelRequest;
-use Illuminate\Http\Response as LaravelResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 final readonly class SessionMiddleware
 {
@@ -21,7 +20,7 @@ final readonly class SessionMiddleware
     {
         $response = $next($request);
 
-        if ($response instanceof LaravelJsonResponse || $response instanceof LaravelResponse) {
+        if ($response instanceof SymfonyResponse) {
             $this->requestExtension->flash(new Request($request), new Response($response));
         }
 

--- a/tests/Laravel/Middleware/SessionMiddlewareTest.php
+++ b/tests/Laravel/Middleware/SessionMiddlewareTest.php
@@ -69,7 +69,7 @@ final class SessionMiddlewareTest extends TestCase
         $requestMock = \Mockery::mock(LaravelRequest::class);
         $responseMock = \Mockery::mock(\Symfony\Component\HttpFoundation\Response::class);
 
-        $this->requestExtensionMock->allows('flash')->never();
+        $this->requestExtensionMock->allows('flash')->once();
 
         $handle = $this->sessionMiddleware->handle($requestMock, fn () => $responseMock);
 


### PR DESCRIPTION
This commit updates the FlasherMiddleware and SessionMiddleware to utilize Symfony's base response class instead of Laravel's. This change ensures broader compatibility and addresses the issue with flash message rendering after page refreshes as identified by the community. Preparing for release in v2.0.2.

See: https://github.com/php-flasher/php-flasher/issues/176
