### PR TITLE
chore: add Laravel excluded paths option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG for 2.x
 
-## [Unreleased](https://github.com/php-flasher/php-flasher/compare/v2.1.0...2.x)
+## [Unreleased](https://github.com/php-flasher/php-flasher/compare/v2.1.1...2.x)
+
+## [v2.1.1](https://github.com/php-flasher/php-flasher/compare/v2.1.0...v2.1.1) - 2024-10-20
+
+* feature [Laravel] Add `excluded_paths` option. See [PR #203](https://github.com/php-flasher/php-flasher/pull/203) by [yoeunes](https://github.com/yoeunes)
 
 ## [v2.1.0](https://github.com/php-flasher/php-flasher/compare/v2.0.4...v2.1.0) - 2024-10-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1967,7 +1967,7 @@
         },
         "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
             "version": "1.3.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {

--- a/src/Laravel/FlasherServiceProvider.php
+++ b/src/Laravel/FlasherServiceProvider.php
@@ -227,10 +227,13 @@ final class FlasherServiceProvider extends PluginServiceProvider
         }
 
         $this->app->singleton(FlasherMiddleware::class, static function (Application $app) {
+            $config = $app->make('config');
+
             $flasher = $app->make('flasher');
             $cspHandler = $app->make('flasher.csp_handler');
+            $excludedPaths = $config->get('flasher.excluded_paths', []) ?: [];
 
-            return new FlasherMiddleware(new ResponseExtension($flasher, $cspHandler));
+            return new FlasherMiddleware(new ResponseExtension($flasher, $cspHandler, $excludedPaths));
         });
 
         $this->pushMiddlewareToGroup(FlasherMiddleware::class);

--- a/src/Laravel/Phpstan/stubs/Repository.stub
+++ b/src/Laravel/Phpstan/stubs/Repository.stub
@@ -13,6 +13,7 @@ namespace Illuminate\Contracts\Config;
  *     scripts: string[],
  *     styles: string[],
  *     options: array<string, mixed>,
+ *     excluded_paths?: list<non-empty-string>,
  *     filter: array<string, mixed>,
  *     flash_bag: array<string, string[]>,
  *     presets: array<string, PresetType>,
@@ -44,6 +45,7 @@ interface Repository
      *            ($key is 'flasher.presets' ? array<string, PresetType> :
      *            ($key is 'flasher.plugins' ? array<string, PluginType> :
      *            ($key is 'flasher.flash_bag' ? array<string, string[]> :
+     *            ($key is 'flasher.excluded_paths' ? list<non-empty-string> :
      *                  mixed)))))))
      */
     public function get(string|array $key, mixed $default = null): mixed;

--- a/src/Laravel/Phpstan/stubs/Repository.stub
+++ b/src/Laravel/Phpstan/stubs/Repository.stub
@@ -46,7 +46,7 @@ interface Repository
      *            ($key is 'flasher.plugins' ? array<string, PluginType> :
      *            ($key is 'flasher.flash_bag' ? array<string, string[]> :
      *            ($key is 'flasher.excluded_paths' ? list<non-empty-string> :
-     *                  mixed)))))))
+     *                  mixed))))))))
      */
     public function get(string|array $key, mixed $default = null): mixed;
 }


### PR DESCRIPTION
This pull request includes changes to add an `excluded_paths` option in the Laravel integration of the `php-flasher` package. The most important changes include updating the `CHANGELOG.md`, modifying the `FlasherServiceProvider` to handle the new option, and updating the `Repository.stub` to include the new configuration option.

Changes related to the new `excluded_paths` option:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R7): Added a new entry for version `v2.1.1`, which includes the new `excluded_paths` option for Laravel.
* [`src/Laravel/FlasherServiceProvider.php`](diffhunk://#diff-0f642bf52b56343538401cb951f8d51e1ba8fb60a2acb948aab091feb76662aeR230-R236): Updated the `registerFlasherMiddleware` method to retrieve and pass the `excluded_paths` configuration to the `FlasherMiddleware`.
* [`src/Laravel/Phpstan/stubs/Repository.stub`](diffhunk://#diff-9879eb41286e4285215f79f5445d638143dc4cb08481506844753d8cf359be12R16): Added the `excluded_paths` option to the docblock and the `get` method's type definitions. [[1]](diffhunk://#diff-9879eb41286e4285215f79f5445d638143dc4cb08481506844753d8cf359be12R16) [[2]](diffhunk://#diff-9879eb41286e4285215f79f5445d638143dc4cb08481506844753d8cf359be12L47-R49)