### PR TITLE
Update Flasher Class Parameter Order

### DIFF
--- a/docs/_includes/_usage.md
+++ b/docs/_includes/_usage.md
@@ -99,7 +99,7 @@ flash()->{{ type }}('{{ message }}');
 These four methods — `success()`, `error()`, `warning()`, and `info()` — are shortcuts for the `flash()` method. They let you specify the `type` and `message` in one method call instead of passing them separately to `flash()`.
 
 ```php
-flash()->flash(string $type, string $message, string $title = null, array $options = [])
+flash()->flash(string $type, string $message, array $options = [], string $title = null)
 ```
 
 {% assign id = '#/ usage flash' %}


### PR DESCRIPTION
The order of `$title` and `$options` has changed, if one tries to pass a string to parameter three ($options) an error is thrown. This updates the docs accordingly.

Looks like the order was changed here:
https://github.com/php-flasher/php-flasher/blob/2.x/src/Prime/helpers.php#L21-L36
