### PR TITLE
Add GitHub workflow for automatic publishing of assets to NPM

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,61 @@
+name: 🚀 Publish assets to NPM
+
+on:
+    release:
+        types: [ published ]
+
+jobs:
+    publish-prime:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: ./src/Prime/Resources
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: '20.x'
+                    registry-url: 'https://registry.npmjs.org'
+
+            -   name: Install dependencies
+                run: npm install
+
+            -   name: Publish to NPM
+                run: npm publish --access public
+                env:
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    publish-plugin:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        strategy:
+            fail-fast: false
+            matrix:
+                path:
+                    - ./src/Noty/Prime/Resources
+                    - ./src/Notyf/Prime/Resources
+                    - ./src/SweetAlert/Prime/Resources
+                    - ./src/Toastr/Prime/Resources
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: '20.x'
+                    registry-url: 'https://registry.npmjs.org'
+
+            -   name: Install dependencies
+                run: npm install
+                working-directory: ${{ matrix.path }}
+
+            -   name: Publish to NPM
+                run: npm publish --access public
+                working-directory: ${{ matrix.path }}
+                env:
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Adds GitHub workflow to automatically publish the JS assets to NPM on new releases. This feature allows the user to separately install the `@flasher` JS libraries for `2.x` and allows containerized tools (like Dependabot) to install (and bump) depedencies without having to depend on assets of the underlying PHP library `php-flasher`.

## Description of Task to be completed
- Fixes #208 

## How should this be manually tested?
1. Create a new release, `2.1.3`.
2. In a Symfony application, separately install assets with NPM.
```json
{
  "dependencies": {
    "@flasher/flasher": "^2.1.3",
    "@flasher/flasher-sweetalert": "^2.1.3",
  }
}
```
3. Add it in your javascript files.
```js
import "sweetalert2/dist/sweetalert2.min.css";

import flasher from "@flasher/flasher";
import '@flasher/flasher-sweetalert';

global.flasher = flasher;
```
4. In `flasher.yaml` add config to explicitely disable `main_script`, `styles` (and same for plugins `scripts` and `styles`).
```yaml
flasher:
  default: sweetalert
  main_script: ~
  styles: ~
  # inject assets to `true` as this only injects the js snippet to display the flash message (no addition core css or js)
  inject_assets: true
  translate: true
  flash_bag:
    success: [ 'success' ]
    error: [ 'error', 'danger' ]
    warning: [ 'warning', 'alarm' ]
    info: [ 'info', 'notice', 'alert' ]
  filter:
    limit: 5

  plugins:
    sweetalert:
      scripts: ~
      styles: ~

  presets:
    hello:
      type: 'info'
      message: 'Welcome back'
      options: &default-options
        toast: true
        position: bottom-end
        showConfirmButton: false
        timer: 7500
```
5. Display flash message from PHP, e.g. `sweetalert()`.

```php
sweetalert()->addPreset('hello');
```
6. Check the message being displayed and styled with the specified plugin styling.
![image](https://github.com/user-attachments/assets/93b0e8c0-e512-42f0-9f16-6b2ec2a47d71)


## Relevant Issues
- #208 

## Background context
- #208 

## Screenshots (Optional)
n/a

## Dependencies
n/a
