### PR TITLE
Fix PHPStan issue by removing includes section from composer.json

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+NPM_FOLDERS=(
+    "src/Prime/Resources"
+    "src/Noty/Prime/Resources"
+    "src/Notyf/Prime/Resources"
+    "src/SweetAlert/Prime/Resources"
+    "src/Toastr/Prime/Resources"
+)
+
+for folder in "${NPM_FOLDERS[@]}"; do
+    if [ -d "$folder" ]; then
+        echo ""
+        echo "Publishing $folder to npm..."
+        (
+            cd "$folder"
+            npm install
+            npm version "$VERSION" --no-git-tag-version || true
+            npm publish --access public
+        )
+    fi
+done
+
+echo "Release $VERSION complete – tagged repositories and published packages to npm."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flasher/php-flasher",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@flasher/php-flasher",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "workspaces": [
                 "src/Prime/Resources",
@@ -8843,7 +8843,7 @@
             }
         },
         "node_modules/is-extglob": {
-            "version": "2.1.1",
+            "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
@@ -10612,7 +10612,7 @@
             }
         },
         "node_modules/nth-check": {
-            "version": "2.1.1",
+            "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
@@ -12330,7 +12330,7 @@
             }
         },
         "node_modules/require-directory": {
-            "version": "2.1.1",
+            "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
@@ -15467,7 +15467,7 @@
         },
         "src/Noty/Prime/Resources": {
             "name": "@flasher/flasher-noty",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "peerDependencies": {
                 "@flasher/flasher": "^2.1.1",
@@ -15476,7 +15476,7 @@
         },
         "src/Notyf/Prime/Resources": {
             "name": "@flasher/flasher-notyf",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "peerDependencies": {
                 "@flasher/flasher": "^2.1.1",
@@ -15485,7 +15485,7 @@
         },
         "src/Prime/Resources": {
             "name": "@flasher/flasher",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "devDependencies": {
                 "csstype": "^3.1.3"
@@ -15493,7 +15493,7 @@
         },
         "src/SweetAlert/Prime/Resources": {
             "name": "@flasher/flasher-sweetalert",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "peerDependencies": {
                 "@flasher/flasher": "^2.1.1",
@@ -15502,7 +15502,7 @@
         },
         "src/Toastr/Prime/Resources": {
             "name": "@flasher/flasher-toastr",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "MIT",
             "devDependencies": {
                 "@types/toastr": "^2.1.43"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@flasher/php-flasher",
     "type": "module",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "license": "MIT",
     "workspaces": [
         "src/Prime/Resources",

--- a/src/Noty/Prime/Resources/package.json
+++ b/src/Noty/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-noty",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-noty.cjs.js",

--- a/src/Notyf/Prime/Resources/package.json
+++ b/src/Notyf/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-notyf",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-notyf.cjs.js",

--- a/src/Prime/Resources/package.json
+++ b/src/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher.cjs.js",

--- a/src/Prime/composer.json
+++ b/src/Prime/composer.json
@@ -41,12 +41,5 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true
-    },
-    "extra": {
-        "phpstan": {
-            "includes": [
-                "extension.neon"
-            ]
-        }
     }
 }

--- a/src/SweetAlert/Prime/Resources/package.json
+++ b/src/SweetAlert/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-sweetalert",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-sweetalert.cjs.js",

--- a/src/Toastr/Prime/Resources/package.json
+++ b/src/Toastr/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-toastr",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-toastr.cjs.js",


### PR DESCRIPTION
This PR addresses an issue preventing PHPStan from running by removing the `phpstan` includes section from the `composer.json` file. The `includes` section was causing conflicts, and its removal resolves the problem, allowing PHPStan to run correctly.