### PR TITLE
add support for Symfony v8.0

### DIFF
--- a/src/Laravel/composer.json
+++ b/src/Laravel/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=8.2",
         "illuminate/support": "^11.0|^12.0",
-        "php-flasher/flasher": "^2.2.0"
+        "php-flasher/flasher": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Noty/Laravel/composer.json
+++ b/src/Noty/Laravel/composer.json
@@ -28,8 +28,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-laravel": "^2.2.0",
-        "php-flasher/flasher-noty": "^2.2.0"
+        "php-flasher/flasher-laravel": "^2.2.1",
+        "php-flasher/flasher-noty": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Noty/Prime/Resources/package.json
+++ b/src/Noty/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-noty",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-noty.cjs.js",
@@ -11,7 +11,7 @@
         "ncu": "ncu -u"
     },
     "peerDependencies": {
-        "@flasher/flasher": "^2.2.0",
+        "@flasher/flasher": "^2.2.1",
         "noty": "^3.2.0-beta-deprecated"
     }
 }

--- a/src/Noty/Prime/composer.json
+++ b/src/Noty/Prime/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher": "^2.2.0"
+        "php-flasher/flasher": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Noty/Symfony/composer.json
+++ b/src/Noty/Symfony/composer.json
@@ -28,8 +28,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-noty": "^2.2.0",
-        "php-flasher/flasher-symfony": "^2.2.0"
+        "php-flasher/flasher-noty": "^2.2.1",
+        "php-flasher/flasher-symfony": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Notyf/Laravel/composer.json
+++ b/src/Notyf/Laravel/composer.json
@@ -29,8 +29,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-laravel": "^2.2.0",
-        "php-flasher/flasher-notyf": "^2.2.0"
+        "php-flasher/flasher-laravel": "^2.2.1",
+        "php-flasher/flasher-notyf": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Notyf/Prime/Resources/package.json
+++ b/src/Notyf/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-notyf",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-notyf.cjs.js",
@@ -11,7 +11,7 @@
         "ncu": "ncu -u"
     },
     "peerDependencies": {
-        "@flasher/flasher": "^2.2.0",
+        "@flasher/flasher": "^2.2.1",
         "notyf": "^3.10.0"
     }
 }

--- a/src/Notyf/Prime/composer.json
+++ b/src/Notyf/Prime/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher": "^2.2.0"
+        "php-flasher/flasher": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Notyf/Symfony/composer.json
+++ b/src/Notyf/Symfony/composer.json
@@ -29,8 +29,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-notyf": "^2.2.0",
-        "php-flasher/flasher-symfony": "^2.2.0"
+        "php-flasher/flasher-notyf": "^2.2.1",
+        "php-flasher/flasher-symfony": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Prime/Flasher.php
+++ b/src/Prime/Flasher.php
@@ -29,7 +29,7 @@ final readonly class Flasher implements FlasherInterface
     /**
      * Current version of PHPFlasher.
      */
-    public const VERSION = '2.2.0';
+    public const VERSION = '2.2.1';
 
     /**
      * Creates a new Flasher instance.

--- a/src/Prime/Resources/package.json
+++ b/src/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher.cjs.js",

--- a/src/SweetAlert/Laravel/composer.json
+++ b/src/SweetAlert/Laravel/composer.json
@@ -30,8 +30,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-laravel": "^2.2.0",
-        "php-flasher/flasher-sweetalert": "^2.2.0"
+        "php-flasher/flasher-laravel": "^2.2.1",
+        "php-flasher/flasher-sweetalert": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/SweetAlert/Prime/Resources/package.json
+++ b/src/SweetAlert/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-sweetalert",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-sweetalert.cjs.js",
@@ -11,7 +11,7 @@
         "ncu": "ncu -u"
     },
     "peerDependencies": {
-        "@flasher/flasher": "^2.2.0",
+        "@flasher/flasher": "^2.2.1",
         "sweetalert2": "^11.6.13"
     }
 }

--- a/src/SweetAlert/Prime/composer.json
+++ b/src/SweetAlert/Prime/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher": "^2.2.0"
+        "php-flasher/flasher": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/SweetAlert/Symfony/composer.json
+++ b/src/SweetAlert/Symfony/composer.json
@@ -30,8 +30,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-sweetalert": "^2.2.0",
-        "php-flasher/flasher-symfony": "^2.2.0"
+        "php-flasher/flasher-sweetalert": "^2.2.1",
+        "php-flasher/flasher-symfony": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -28,7 +28,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher": "^2.2.0",
+        "php-flasher/flasher": "^2.2.1",
         "symfony/config": "^7.0|^8.0",
         "symfony/console": "^7.0|^8.0",
         "symfony/dependency-injection": "^7.0|^8.0",

--- a/src/Toastr/Laravel/composer.json
+++ b/src/Toastr/Laravel/composer.json
@@ -29,8 +29,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-laravel": "^2.2.0",
-        "php-flasher/flasher-toastr": "^2.2.0"
+        "php-flasher/flasher-laravel": "^2.2.1",
+        "php-flasher/flasher-toastr": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Toastr/Prime/Resources/package.json
+++ b/src/Toastr/Prime/Resources/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flasher/flasher-toastr",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "module",
     "license": "MIT",
     "main": "dist/flasher-toastr.cjs.js",
@@ -11,7 +11,7 @@
         "ncu": "ncu -u"
     },
     "peerDependencies": {
-        "@flasher/flasher": "^2.2.0",
+        "@flasher/flasher": "^2.2.1",
         "toastr": "^2.1.4"
     },
     "devDependencies": {

--- a/src/Toastr/Prime/composer.json
+++ b/src/Toastr/Prime/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher": "^2.2.0"
+        "php-flasher/flasher": "^2.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Toastr/Symfony/composer.json
+++ b/src/Toastr/Symfony/composer.json
@@ -29,8 +29,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "php-flasher/flasher-symfony": "^2.2.0",
-        "php-flasher/flasher-toastr": "^2.2.0"
+        "php-flasher/flasher-symfony": "^2.2.1",
+        "php-flasher/flasher-toastr": "^2.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bumps the php-flasher dependencies in composer.json and package.json files
to version 2.2.1 across all relevant packages.

This ensures the project utilizes the latest features,
bug fixes, and improvements available in the php-flasher library.
